### PR TITLE
Attempted fix at a yaml parsing issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: ''
   verifyDownload:
     required: false
-    description: 'Verify the downloaded reporter''s checksum and GPG signature'
+    description: 'Verify the downloaded reporter their checksum and GPG signature'
     default: 'true'
 runs:
   using: 'node12'


### PR DESCRIPTION
Error: paambaati/codeclimate-action/v3/action.yml: (Line: 30, Col: 51, Idx: 902) - 
  (Line: 30, Col: 80, Idx: 931): While parsing a block mapping, did not find expected key.
Error: System.ArgumentException: Unexpected type '' encountered while reading 'action manifest root'. The type 'MappingToken' was expected.